### PR TITLE
New api endpoints

### DIFF
--- a/test-suites/helpers.js
+++ b/test-suites/helpers.js
@@ -25,17 +25,31 @@ function expectCommonResponse({ res, includeMeta = false }) {
   }
 }
 
+const newsShape = {
+  title: expect.any(String),
+  summary: expect.any(String),
+  link: expect.any(String)
+}
+
+function expectNewsShape(newsArticle) {
+  expect(newsArticle).toEqual(
+    expect.objectContaining(newsShape)
+  );
+}
+
+const mediaRegex = /\.jpg/;
+const heroShape = {
+  title: expect.any(String),
+  caption: expect.any(String),
+  default: expect.stringMatching(mediaRegex),
+  small: expect.stringMatching(mediaRegex),
+  medium: expect.stringMatching(mediaRegex),
+  large: expect.stringMatching(mediaRegex)
+};
+
 function expectHeroShape(heroImage) {
-  const mediaRegex = /\.jpg/;
   expect(heroImage).toEqual(
-    expect.objectContaining({
-      title: expect.any(String),
-      caption: expect.any(String),
-      default: expect.stringMatching(mediaRegex),
-      small: expect.stringMatching(mediaRegex),
-      medium: expect.stringMatching(mediaRegex),
-      large: expect.stringMatching(mediaRegex)
-    })
+    expect.objectContaining(heroShape)
   );
 }
 
@@ -44,5 +58,8 @@ module.exports = {
   apiUrl,
   expectListShape,
   expectCommonResponse,
+  newsShape,
+  expectNewsShape,
+  heroShape,
   expectHeroShape
 };

--- a/test-suites/hero-image.test.js
+++ b/test-suites/hero-image.test.js
@@ -1,7 +1,7 @@
 const superagent = require('superagent');
 const { apiUrl, expectCommonResponse, expectHeroShape } = require('./helpers');
 
-test.skip('it should return hero image for a given slug', () => {
+test('it should return hero image for a given slug', () => {
   return superagent
     .get(apiUrl('/v1/en/hero-image/passion-4-fusion'))
     .then(res => {

--- a/test-suites/homepage.test.js
+++ b/test-suites/homepage.test.js
@@ -1,0 +1,26 @@
+const superagent = require('superagent');
+const { apiUrl, expectCommonResponse, expectListShape, newsShape } = require('./helpers');
+
+const mediaRegex = /\.jpg/;
+const homepageHeroShape = {
+  caption: expect.any(String),
+  default: expect.stringMatching(mediaRegex),
+  small: expect.stringMatching(mediaRegex),
+  medium: expect.stringMatching(mediaRegex),
+  large: expect.stringMatching(mediaRegex)
+};
+
+test('it should data for the homepage', () => {
+  return superagent
+    .get(apiUrl('/v1/en/homepage'))
+    .then(res => {
+      const { body } = res;
+      const attrs = body.data.attributes;
+      expectCommonResponse({ res });
+      expect(attrs.heroImages.default).toEqual(
+        expect.objectContaining(homepageHeroShape)
+      );
+      expectListShape(attrs.heroImages.candidates, homepageHeroShape);
+      expectListShape(attrs.newsArticles, newsShape);
+    });
+});

--- a/test-suites/promoted-news.test.js
+++ b/test-suites/promoted-news.test.js
@@ -1,6 +1,5 @@
 const superagent = require('superagent');
-const { mapAttrs, apiUrl, expectCommonResponse } = require('./helpers');
-const { sample } = require('lodash/fp');
+const { mapAttrs, apiUrl, expectCommonResponse, expectListShape, newsShape } = require('./helpers');
 
 test('it should return a list of promoted news', () => {
   return superagent.get(apiUrl('/v1/en/promoted-news')).then(res => {
@@ -8,9 +7,6 @@ test('it should return a list of promoted news', () => {
     expectCommonResponse({ res, includeMeta: true });
     const attrs = mapAttrs(body);
     expect(attrs.length).toBeGreaterThanOrEqual(3);
-    const sampled = sample(attrs);
-    expect(Object.keys(sampled)).toEqual(
-      expect.arrayContaining(['title', 'summary', 'link'])
-    );
+    expectListShape(attrs, newsShape);
   });
 });


### PR DESCRIPTION
Add homepage API endpoint test, refactor news article tests, enable hero image test.

Dependant on https://github.com/biglotteryfund/craft-dev/pull/60, can be merged once `/hero-image` endpoint is on the live CMS.